### PR TITLE
Allow CPU-only build without CUDA

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,32 +1,38 @@
 cmake_minimum_required(VERSION 3.24)
-project(tht_miner_cuda LANGUAGES CXX CUDA)
+project(tht_miner LANGUAGES CXX)
 
-# (Опционально закрепим компиляторы — ты уже сделал это в build.sh)
-if(NOT DEFINED CMAKE_C_COMPILER)
+# Optional CUDA support
+option(USE_CUDA "Build with CUDA support" ON)
+if(USE_CUDA)
+  find_package(CUDAToolkit QUIET)
+  if(CUDAToolkit_FOUND)
+    enable_language(CUDA)
+  else()
+    message(WARNING "CUDA toolkit not found; building CPU-only")
+    set(USE_CUDA OFF)
+  endif()
+endif()
+
+if(EXISTS "/usr/bin/gcc-12" AND EXISTS "/usr/bin/g++-12")
   set(CMAKE_C_COMPILER /usr/bin/gcc-12)
-endif()
-if(NOT DEFINED CMAKE_CXX_COMPILER)
   set(CMAKE_CXX_COMPILER /usr/bin/g++-12)
-endif()
-if(NOT DEFINED CMAKE_CUDA_HOST_COMPILER)
-  set(CMAKE_CUDA_HOST_COMPILER /usr/bin/g++-12)
 endif()
 
 set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
-set(CMAKE_CUDA_STANDARD 17)
-set(CMAKE_CUDA_STANDARD_REQUIRED ON)
 
-# Куда складывать артефакты
+if(USE_CUDA)
+  set(CMAKE_CUDA_STANDARD 17)
+  set(CMAKE_CUDA_STANDARD_REQUIRED ON)
+  if(NOT DEFINED CMAKE_CUDA_ARCHITECTURES)
+    set(CMAKE_CUDA_ARCHITECTURES 86)
+  endif()
+endif()
+
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin)
 set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib)
 
-# Архитектуры CUDA (подбери под свою карту)
-# 86 = Ampere (RTX 30), 89 = Ada (RTX 40)
-# Если не уверен — оставь 86; при желании установим через -DCMAKE_CUDA_ARCHITECTURES
-if(NOT DEFINED CMAKE_CUDA_ARCHITECTURES)
-  set(CMAKE_CUDA_ARCHITECTURES 86)
-endif()
+find_package(OpenSSL REQUIRED)
+find_package(Threads REQUIRED)
 
 add_subdirectory(src)
-

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -5,20 +5,21 @@ cd "$(dirname "$0")/.."
 BUILD_DIR="build"
 GEN="Ninja"
 TYPE="${TYPE:-Release}"
-
-# Можно передать ARCH=89 ./scripts/build.sh
 ARCH="${ARCH:-86}"
 
-export CC=/usr/bin/gcc-12
-export CXX=/usr/bin/g++-12
-
-cmake -S . -B "$BUILD_DIR" -G "$GEN" \
-  -DCMAKE_BUILD_TYPE="$TYPE" \
-  -DCMAKE_C_COMPILER=/usr/bin/gcc-12 \
-  -DCMAKE_CXX_COMPILER=/usr/bin/g++-12 \
-  -DCMAKE_CUDA_HOST_COMPILER=/usr/bin/g++-12 \
-  -DCMAKE_CUDA_ARCHITECTURES="${ARCH}"
+if command -v nvcc >/dev/null 2>&1; then
+  cmake -S . -B "$BUILD_DIR" -G "$GEN" \
+    -DCMAKE_BUILD_TYPE="$TYPE" \
+    -DUSE_CUDA=ON \
+    -DCMAKE_CUDA_ARCHITECTURES="${ARCH}"
+else
+  echo "nvcc not found; building CPU-only"
+  cmake -S . -B "$BUILD_DIR" -G "$GEN" \
+    -DCMAKE_BUILD_TYPE="$TYPE" \
+    -DUSE_CUDA=OFF
+fi
 
 cmake --build "$BUILD_DIR" -j
+
 echo "== Build done =="
 echo "Binary: $BUILD_DIR/bin/thtminer"

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,16 +1,56 @@
-# Библиотека с CUDA-обвязкой (без PoW-ядра; только self-test и инфо)
-add_library(cuda_core STATIC
-    core/CudaSolver.cu
-    core/CudaSolver.hpp
-)
+add_library(cuda_core STATIC)
+
 target_include_directories(cuda_core PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
-set_target_properties(cuda_core PROPERTIES
-    POSITION_INDEPENDENT_CODE ON
-    CUDA_SEPARABLE_COMPILATION ON
-)
-target_compile_options(cuda_core PRIVATE
-    $<$<COMPILE_LANGUAGE:CUDA>:--use_fast_math>
-    $<$<COMPILE_LANGUAGE:CXX>:-Wall>
-    $<$<COMPILE_LANGUAGE:CXX>:-Wextra>
-    $<$<COMPILE_LANGUAGE:CXX>:-Wno-unused-parameter>
-)
+
+if(USE_CUDA)
+    target_sources(cuda_core PRIVATE
+        core/CudaSolver.cu
+        core/CudaKernel.cu
+        core/CudaSha256d.cuh
+        core/CudaSolver.hpp)
+    set_target_properties(cuda_core PROPERTIES
+        POSITION_INDEPENDENT_CODE ON
+        CUDA_SEPARABLE_COMPILATION ON)
+    target_compile_options(cuda_core PRIVATE
+        $<$<COMPILE_LANGUAGE:CUDA>:--use_fast_math>
+        $<$<COMPILE_LANGUAGE:CXX>:-Wall>
+        $<$<COMPILE_LANGUAGE:CXX>:-Wextra>
+        $<$<COMPILE_LANGUAGE:CXX>:-Wno-unused-parameter>)
+else()
+    target_sources(cuda_core PRIVATE
+        core/CudaSolver.cpp
+        core/CudaSolver.hpp)
+    target_compile_options(cuda_core PRIVATE
+        $<$<COMPILE_LANGUAGE:CXX>:-Wall>
+        $<$<COMPILE_LANGUAGE:CXX>:-Wextra>
+        $<$<COMPILE_LANGUAGE:CXX>:-Wno-unused-parameter>)
+endif()
+
+add_library(util STATIC
+    util/Util.cpp
+    util/Util.hpp)
+
+target_include_directories(util PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
+
+add_library(stratum STATIC
+    stratum/StratumClient.cpp
+    stratum/StratumClient.hpp)
+
+target_include_directories(stratum PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
+
+target_link_libraries(stratum PUBLIC util)
+
+add_library(miner STATIC
+    miner/CpuMiner.cpp
+    miner/CpuMiner.hpp
+    miner/MinerApp.cpp
+    miner/MinerApp.hpp)
+
+target_include_directories(miner PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
+
+target_link_libraries(miner PUBLIC stratum util cuda_core OpenSSL::Crypto Threads::Threads)
+
+add_executable(thtminer
+    cli/main.cpp)
+
+target_link_libraries(thtminer PRIVATE miner)

--- a/src/core/CudaSolver.cpp
+++ b/src/core/CudaSolver.cpp
@@ -1,0 +1,22 @@
+#include "CudaSolver.hpp"
+#include <cstdio>
+
+using namespace tht;
+
+void CudaSolver::self_test() {
+    std::puts("[CUDA] self-test skipped (built without CUDA)");
+}
+
+void CudaSolver::gpu_mine_once_and_submit(const Job&,
+                                          const std::string&,
+                                          const std::vector<std::string>&,
+                                          const std::string&,
+                                          const std::string&,
+                                          StratumClient&,
+                                          double) {
+    std::puts("[CUDA] gpu_mine_once_and_submit not available in CPU-only build");
+}
+
+void CudaSolver::probe_devices() {}
+void CudaSolver::init() {}
+void CudaSolver::run_dummy_kernel() {}


### PR DESCRIPTION
## Summary
- make CUDA optional in CMake and provide CPU-only stub
- compile miner, stratum and util components into thtminer executable
- build script now falls back to CPU-only when nvcc is missing

## Testing
- `scripts/build.sh`
- `./build/bin/thtminer --help`

------
https://chatgpt.com/codex/tasks/task_e_68b885cdcd7c832e82217e999fda65a4